### PR TITLE
When listing pull requests the correct behavior is to print pr's owner not repo's name.

### DIFF
--- a/lib/cmds/templates/pr.handlebars
+++ b/lib/cmds/templates/pr.handlebars
@@ -2,7 +2,7 @@
 {{#each branches}}
 {{../prefix}}   {{name}} ({{total}})
 {{#each pulls}}
-{{../../prefix}}     {{{greenBright "#" number}}} {{{title}}} {{{magentaBright "@" head.user.login}}} ({{date created_at}})
+{{../../prefix}}     {{{greenBright "#" number}}} {{{title}}} {{{magentaBright "@" user.login}}} ({{date created_at}})
 {{#if ../../detailed}}
 {{../../../prefix}}     {{{blueBright html_url}}}
 {{#if body}}


### PR DESCRIPTION
Wrong username:
![wrong](https://f.cloud.github.com/assets/827445/1128254/56cfed94-1b5c-11e3-880b-b43202897e59.png)

Correct username:
![correct](https://f.cloud.github.com/assets/827445/1128255/65a03b80-1b5c-11e3-9913-add3111bbdbb.png)
