### PR TITLE
Error in the help regarding option with multiple params types (Number, Array)

### DIFF
--- a/lib/cmds/help.js
+++ b/lib/cmds/help.js
@@ -118,8 +118,27 @@ Help.prototype.groupOptions_ = function(details) {
     return grouped;
 };
 
+Help.prototype.getMixedTypes_ = function (types) {
+    var instance = this,
+        i;
+
+    for (i in types) {
+        if (types.hasOwnProperty(i) && typeof types[i] === 'function') {
+            //note that if the type object is accepted recursively here this might get dangerous
+            types[i] = instance.getType_(types[i]);
+        }
+    }
+
+    return types;
+};
+
 Help.prototype.getType_ = function(type) {
+    var instance = this;
+
     switch(type) {
+        case Array:
+            type = 'Array';
+            break;
         case String:
             type = 'String';
             break;
@@ -138,6 +157,13 @@ Help.prototype.getType_ = function(type) {
         case Date:
             type = 'Date';
             break;
+        case Boolean:
+            break;
+    }
+
+    //verify if the type is object
+    if (typeof type === 'object') {
+        type = instance.getMixedTypes_(type);
     }
 
     return type;


### PR DESCRIPTION
For example, the gh pr and gh is accept arrays of numbers.

Then in the options we have:
`'number'   : [Number, Array]`

This is what I see on the help:

```
gh    ➜  pr, pull-request Provides a set of util commands to work with Pull Requests.
gh         -a, --all
gh         -b, --branch (String)
gh         -B, --browser
gh         -C, --close
gh         -c, --comment (String)
gh         -D, --description (String)
gh         -d, --detailed
gh         -f, --fetch
gh         --fwd (String)
gh         -i, --issue (Number)
gh         -l, --list
gh         -M, --merge
gh         -n, --number (function Number() { [native code] },function Array() { [native code] })
gh         -o, --open
gh         -R, --rebase
gh         --remote (String)
gh         -r, --repo (String)
gh         -S, --state (open,closed)
gh         -s, --submit (String)
gh         -t, --title (String)
gh         -u, --user (String)
```

Notice the

```
gh         -n, --number (function Number() { [native code] },function Array() { [native code] })
```

Is this only happening with me or with you also?
