### PR TITLE
Fixed relative date being humanized in reverse

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -188,7 +188,7 @@ exports.getDuration = function(start, opt_end) {
         opt_end = Date.now();
     }
 
-    return moment.duration(moment(opt_end).diff(start)).humanize(true);
+    return moment.duration(moment(start).diff(opt_end)).humanize(true);
 };
 
 exports.getNodeModulesGlobalPath = function() {


### PR DESCRIPTION
This fixes the output from commands like `gh issue, nt etc`, changing output from:

```
gh ➜ node-gh/gh
gh   @rschmukler forked gh (in 13 minutes)
```

to:

```
gh ➜ node-gh/gh
gh   @rschmukler forked gh (13 minutes ago)
```
