### PR TITLE
Add automatic CC to forwarded PRs

### DIFF
--- a/.gh.json
+++ b/.gh.json
@@ -9,6 +9,8 @@
 
     "default_remote": "origin",
 
+    "fwd_description": "{{options.description}}\n\ncc @{{pull.user.login}}",
+
     "git_command": "git",
 
     "github_token": "",

--- a/lib/cmds/pull-request.js
+++ b/lib/cmds/pull-request.js
@@ -427,6 +427,11 @@ PullRequest.prototype.forward = function(opt_callback) {
         },
         function(callback) {
             options.title = pull.title;
+            options.description = logger.compileTemplate(config.fwd_description, {
+                options: options,
+                pull: pull
+            });
+
             instance.submit(options.fwd, function(err, data) {
                 submittedPull = data;
                 callback(err);


### PR DESCRIPTION
Hey @eduardolundgren, @zenorocha 

This is something guys at the office were asking for. It's useful to be able to automatically cc the original sender, so that he can easily track the state and comments on the new PR.

Maybe it could even be improved by using the participants list... what do you think?
