### PR TITLE
Fix git clone directory name error.

### DIFF
--- a/lib/cmds/repo.js
+++ b/lib/cmds/repo.js
@@ -175,7 +175,7 @@ Repo.prototype.run = function() {
                     if (options.clone) {
                         git.clone(
                             url.parse(repo.ssh_url).href,
-                            null,
+                            options.new,
                             function(err2, data) {
                                 console.log(data);
                             });


### PR DESCRIPTION
I think it's enough to fix this bug. #237

@eduardolundgren, @zenorocha. What is the idea to do this `options.repo = options.new`?
I never know when I should use one or another.
