### PR TITLE
Adding right err message instead of exit code for the git pull-request --fetch

### DIFF
--- a/lib/cmds/pull-request.js
+++ b/lib/cmds/pull-request.js
@@ -388,7 +388,9 @@ PullRequest.prototype.fetch = function(opt_type, opt_callback) {
             });
         },
         function(callback) {
-            git.exec('fetch', [repoUrl, headBranch + ':' + options.pullBranch], callback);
+            git.exec('fetch', [repoUrl, headBranch + ':' + options.pullBranch], function(status, err) {
+                callback(err);
+            });
         },
         function(callback) {
             if (opt_type === PullRequest.FETCH_TYPE_REBASE) {


### PR DESCRIPTION
This pull request makes gh more verbose by copying the stderr (standard error) to the cli instead of simply failing silently.

For example:

```
$ gh pr -n 2 -u eduardolundgren --fetch
gh [info] Fetching pull request #2 into branch pr-2
gh [error] fatal: Refusing to fetch into current branch refs/heads/pr-2 of non-bare repository
fatal: The remote end hung up unexpectedly
```

instead of

```
$ gh pr -n 2 -u eduardolundgren --fetch
gh [info] Fetching pull request #2 into branch pr-2
gh [error] 128
```
