### PR TITLE
User can't login with user / password more than once (e.g., on 2+ machines)

### DIFF
--- a/lib/cmds/user.js
+++ b/lib/cmds/user.js
@@ -16,6 +16,7 @@
 var base = require('../base'),
     logger = require('../logger'),
     inquirer = require('inquirer'),
+    moment = require('moment'),
     config = base.getConfig();
 
 // -- Constructor ----------------------------------------------------------------------------------
@@ -100,7 +101,7 @@ User.createAuthorization = function(opt_callback) {
             }
         ], function(answers) {
             var payload = {
-                note: 'Node GH',
+                note: 'Node GH (' + moment().format('MMMM Do YYYY, h:mm:ss a') + ')',
                 note_url: 'https://github.com/eduardolundgren/node-gh',
                 scopes: ['user', 'public_repo', 'repo', 'repo:status', 'delete_repo', 'gist']
             };


### PR DESCRIPTION
On https://github.com/settings/applications there is a list of application tokens.

The list is divided in two: personal access tokens, authorized applications, and GitHub applications.

Currently node-gh is shown on the personal access tokens list.

It appears GitHub now is using the 'note' field (used for application description) as a unique identifier for some unknown reason.

I've contacted their support and am waiting for a answer.

See https://github.com/defunkt/gist/commit/a65f64efae6da00fcfa5916f9a5bcac8fee9de7a and https://github.com/defunkt/gist/issues/166 for a workaround related to this.

I think there are two options if GitHub doesn't fix the issue fast (or decide it's a feature):
1) adopt such strategy (which I'm not a fan of) *
2) verify if we can get node-gh listed as a application and get a client id on  https://github.com/settings/applications/new to avoid this by reusing the token (it seems to be avoidable doing so), but https://github.com/mikedeboer/node-github/ doesn't have support to this as of this time
