### PR TITLE
Adding error message for failure in reading corrupted gh.json file

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -80,6 +80,7 @@ exports.getConfig = function(opt_plugin) {
         return config;
     }
     catch (err) {
+        logger.error('Reading the config: ' + err);
         return {};
     }
 };


### PR DESCRIPTION
This is useful if you edit your file manually and corrupt it and don't notice. Without this gh.json will keep failling silently because it won't  get the credentials or other configs and you will never know why.
