### PR TITLE
Read and update more info from/to issues

### DIFF
--- a/lib/cmds/issue.js
+++ b/lib/cmds/issue.js
@@ -258,7 +258,7 @@ Issue.prototype.editIssue_ = function(title, state, opt_callback) {
     };
 
     if (typeof options.label == 'string') {
-        payload.label = options.label.split(',');
+        payload.labels = options.label.split(',');
     }
 
     base.github.issues.edit(payload, opt_callback);

--- a/lib/cmds/issue.js
+++ b/lib/cmds/issue.js
@@ -256,6 +256,7 @@ Issue.prototype.editIssue_ = function(title, state, opt_callback) {
     payload = {
         labels: options.label,
         number: options.number,
+        assignee: options.assignee,
         milestone: options.milestone,
         repo: options.repo,
         state: state,

--- a/lib/cmds/issue.js
+++ b/lib/cmds/issue.js
@@ -317,11 +317,25 @@ Issue.prototype.list = function(user, repo, opt_callback) {
 
         var issues = [];
 
-        results.forEach(function(result) {
-            if (result) {
-                issues = issues.concat(result);
-            }
-        });
+        if (options.number) {
+            results.forEach(function(result) {
+                if (!result) {
+                    return;
+                }
+
+                result.forEach(function(issue) {
+                    if (options.number == issue.number) {
+                        issues.push(issue);
+                    }
+                });
+            });
+        } else {
+            results.forEach(function(result) {
+                if (result) {
+                    issues = issues.concat(result);
+                }
+            });
+        }
 
         issues.sort(function(a, b) {
             return a.number > b.number ? -1 : 1;

--- a/lib/cmds/issue.js
+++ b/lib/cmds/issue.js
@@ -249,6 +249,10 @@ Issue.prototype.editIssue_ = function(title, state, opt_callback) {
 
     options.label = options.label || [];
 
+    if (typeof options.label) {
+        options.label = options.label.split(',');
+    }
+
     payload = {
         labels: options.label,
         number: options.number,

--- a/lib/cmds/issue.js
+++ b/lib/cmds/issue.js
@@ -249,7 +249,7 @@ Issue.prototype.editIssue_ = function(title, state, opt_callback) {
 
     options.label = options.label || [];
 
-    if (typeof options.label) {
+    if (typeof options.label == 'string') {
         options.label = options.label.split(',');
     }
 

--- a/lib/cmds/issue.js
+++ b/lib/cmds/issue.js
@@ -257,7 +257,7 @@ Issue.prototype.editIssue_ = function(title, state, opt_callback) {
         user: options.user
     };
 
-    if (typeof options.label == 'string') {
+    if (typeof options.label === 'string') {
         payload.labels = options.label.split(',');
     }
 
@@ -327,7 +327,7 @@ Issue.prototype.list = function(user, repo, opt_callback) {
                 }
 
                 result.forEach(function(issue) {
-                    if (options.number == issue.number) {
+                    if (options.number === issue.number) {
                         issues.push(issue);
                     }
                 });

--- a/lib/cmds/issue.js
+++ b/lib/cmds/issue.js
@@ -256,6 +256,7 @@ Issue.prototype.editIssue_ = function(title, state, opt_callback) {
     payload = {
         labels: options.label,
         number: options.number,
+        milestone: options.milestone,
         repo: options.repo,
         state: state,
         title: title,

--- a/lib/cmds/issue.js
+++ b/lib/cmds/issue.js
@@ -247,14 +247,7 @@ Issue.prototype.editIssue_ = function(title, state, opt_callback) {
         options = instance.options,
         payload;
 
-    options.label = options.label || [];
-
-    if (typeof options.label == 'string') {
-        options.label = options.label.split(',');
-    }
-
     payload = {
-        labels: options.label,
         number: options.number,
         assignee: options.assignee,
         milestone: options.milestone,
@@ -263,6 +256,10 @@ Issue.prototype.editIssue_ = function(title, state, opt_callback) {
         title: title,
         user: options.user
     };
+
+    if (typeof options.label == 'string') {
+        payload.label = options.label.split(',');
+    }
 
     base.github.issues.edit(payload, opt_callback);
 };

--- a/lib/cmds/templates/issue.handlebars
+++ b/lib/cmds/templates/issue.handlebars
@@ -7,7 +7,7 @@
 {{../../../prefix}}     > {{{wordwrap body 6}}}
 {{/if}}
 {{#if labels}}
-{{../../../prefix}}     {{{greenBright "labels: "}}}{{#each labels}}{{{blueBright name}}}{{#unless @last}},{{/unless}}{{/each}}
+{{../../../prefix}}     {{{greenBright "labels:"}}}  {{#each labels}}{{name}}{{#unless @last}},{{/unless}}{{/each}}
 {{/if}}
 {{../../prefix}}
 {{/if}}

--- a/lib/cmds/templates/issue.handlebars
+++ b/lib/cmds/templates/issue.handlebars
@@ -7,7 +7,7 @@
 {{../../../prefix}}     > {{{wordwrap body 6}}}
 {{/if}}
 {{#if labels}}
-{{../../../prefix}}     {{{greenBright "labels: "}}}{{#each labels}}{{{blueBright name}}}{{#unless @last}}|{{/unless}}{{/each}}
+{{../../../prefix}}     {{{greenBright "labels: "}}}{{#each labels}}{{{blueBright name}}}{{#unless @last}},{{/unless}}{{/each}}
 {{/if}}
 {{../../prefix}}
 {{/if}}

--- a/lib/cmds/templates/issue.handlebars
+++ b/lib/cmds/templates/issue.handlebars
@@ -6,6 +6,9 @@
 {{#if body}}
 {{../../../prefix}}     > {{{wordwrap body 6}}}
 {{/if}}
+{{#if labels}}
+{{../../../prefix}}     {{{greenBright "labels: "}}}{{#each labels}}{{{blueBright name}}}{{#unless @last}}|{{/unless}}{{/each}}
+{{/if}}
 {{../../prefix}}
 {{/if}}
 {{/each}}

--- a/lib/cmds/templates/issue.handlebars
+++ b/lib/cmds/templates/issue.handlebars
@@ -9,6 +9,9 @@
 {{#if labels}}
 {{../../../prefix}}     {{{greenBright "labels:"}}}  {{#each labels}}{{name}}{{#unless @last}},{{/unless}}{{/each}}
 {{/if}}
+{{#if milestone}}
+{{../../../prefix}}     {{{greenBright "milestone:"}}} {{{milestone.title}}} - {{{milestone.number}}}
+{{/if}}
 {{../../prefix}}
 {{/if}}
 {{/each}}


### PR DESCRIPTION
This pull request add the next features:

- [ ] Allows to set the issue labels with a coma list `label1,label2,label3`
- [ ] Allows to change the issue `assignee`
- [ ] Allows to change the issue `milestone`
- [ ] Allows to use `-n` when listing issues `gh is --list -n NUMBER` so you can get one issue info
- [ ] Add the labels info to the `--detailed` issue template
- [ ] Add the milestone info to the `--detailed` issue template

