### PR TITLE
small improvemenet assume -B option when doing "gh is <number>"

### DIFF
--- a/lib/cmds/issue.js
+++ b/lib/cmds/issue.js
@@ -83,12 +83,14 @@ Issue.DETAILS = {
         'u': ['--user']
     },
     payload: function(payload, options) {
-        if (payload[0]) {
+        if (payload.length === 1 && !isNaN(payload[0])) {
+            options.browser = true;
+            options.number = parseInt(payload[0], 10);
+        } else if (payload[0]) {
             options.new = true;
             options.title = options.title || payload[0];
             options.message = options.message || payload[1];
-        }
-        else {
+        } else {
             options.list = true;
         }
     }


### PR DESCRIPTION
This is an small improvement that helps on my workflow. 

If I do `gh is 450`, it will open the browser (no need the -B option).

Because, I'll never create an issue that has as a title just a number and no message at all.

Thanks for this utility!
