### PR TITLE
X-GitHub-OTP Error

### DIFF
--- a/lib/cmds/user.js
+++ b/lib/cmds/user.js
@@ -176,6 +176,10 @@ User.twoFactorAuthenticator_ = function(payload, user, opt_callback) {
                 name: 'otp'
             }
         ], function(factor) {
+            if (!payload.headers) {
+                payload.headers = [];
+            }
+
             payload.headers['X-GitHub-OTP'] = factor.otp;
 
             base.github.authorization.create(payload, function(err, res) {


### PR DESCRIPTION
I just installed and I'm trying to authenticate and I'm getting:

`Cannot set property 'X-GitHub-OTP' of undefined`

![img](https://dl.dropboxusercontent.com/u/21831023/tmp/Screenshot%202014-11-25%2023.31.10.png)
(I deleted my password `*`s and auth code from the image)

What am I missing?
