### PR TITLE
Using .some instead of .every in `hasCommandInOptions`

### DIFF
--- a/lib/cmd.js
+++ b/lib/cmd.js
@@ -91,20 +91,15 @@ if (!command) {
 // -- Utils ----------------------------------------------------------------------------------------
 
 function hasCommandInOptions(commands, options) {
-    var found = false;
-
     if (commands) {
-        commands.every(function(c) {
-            if (options[c] !== undefined) {
-                found = true;
-                return false;
-            }
-            return true;
+        return commands.some(function(c) {
+            return options[c] !== undefined;
         });
     }
 
-    return found;
+    return false;
 }
+
 
 function invokePayload(options, command, cooked, remain) {
     var payload;


### PR DESCRIPTION
`.some` always return `true` if **true** was found, otherwise: `false` will be returned.

:beers: 