### PR TITLE
Fix issue where forking to an organization would not work.

### DIFF
--- a/lib/cmds/repo.js
+++ b/lib/cmds/repo.js
@@ -272,7 +272,7 @@ Repo.prototype.fork = function(opt_callback) {
     };
 
     if (options.organization) {
-        payload.org = options.organization;
+        payload.organization = options.organization;
     }
 
     base.github.repos.fork(payload, opt_callback);


### PR DESCRIPTION
The issue is that the github library uses "organization" and not "org".