### PR TITLE
Replace ascii.io by asciinema.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
         <div class="row">
           <div class="span2"></div>
           <div class="span8">
-            <iframe src="http://ascii.io/a/3391/raw" frameborder="0"></iframe>
+            <iframe src="https://asciinema.org/a/3391/raw" frameborder="0"></iframe>
           </div>
           <div class="span2"></div>
         </div>


### PR DESCRIPTION
Apparently the ascii.io domain is no longer on air, so we'll replace by asciinema.org which is the same service.