### PR TITLE
spdx-compliant license string

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "twitter": "zenorocha"
     }
   ],
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
     "url": "git@github.com:node-gh/gh.git"


### PR DESCRIPTION
Change license string in `package.json` to silence warning
in latest `npm`