### PR TITLE
Travis-CI: Migrate from legacy infrastructure to container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
     - "0.12"
     - iojs
+sudo: false
 before_install:
     - sh ci.sh
 script:


### PR DESCRIPTION
See http://docs.travis-ci.com/user/migrating-from-legacy/

Basically, it appears that all is needed is to add `sudo: false` to `.travis.yml`. I'll submit a PR after I have given it a try to see if there's any issue with the current setup.