### PR TITLE
Limit repository listing output based on stdout.isTTY

### DIFF
--- a/lib/cmd.js
+++ b/lib/cmd.js
@@ -165,6 +165,9 @@ exports.setUp = function () {
         var iterativeValues,
             remoteUrl = git.getRemoteUrl(options.remote);
 
+        options.isTTY = {};
+        options.isTTY.in = Boolean(process.stdin.isTTY);
+        options.isTTY.out = Boolean(process.stdout.isTTY);
         options.loggedUser = base.getUser();
         options.remoteUser = git.getUserFromRemoteUrl(remoteUrl);
 

--- a/lib/cmds/repo.js
+++ b/lib/cmds/repo.js
@@ -55,7 +55,7 @@ Repo.DETAILS = {
         'organization': String,
         'private': Boolean,
         'repo': String,
-        'type': ['all', 'member', 'owner', 'public', 'private'],
+        'type': ['all', 'forks', 'member', 'owner', 'public', 'private', 'sources'],
         'user': String
     },
     shorthands: {
@@ -78,10 +78,12 @@ Repo.DETAILS = {
 };
 
 Repo.TYPE_ALL = 'all';
+Repo.TYPE_FORKS = 'forks';
 Repo.TYPE_MEMBER = 'member';
 Repo.TYPE_OWNER = 'owner';
 Repo.TYPE_PRIVATE = 'private';
 Repo.TYPE_PUBLIC = 'public';
+Repo.TYPE_SOURCES = 'sources';
 
 // -- Commands -------------------------------------------------------------------------------------
 
@@ -89,8 +91,6 @@ Repo.prototype.run = function() {
     var instance = this,
         options = instance.options,
         user = options.loggedUser;
-
-    options.type = options.type || Repo.TYPE_ALL;
 
     if (options.browser) {
         instance.browser(options.user, options.repo);
@@ -154,14 +154,19 @@ Repo.prototype.run = function() {
     }
 
     if (options.list) {
-        user = options.user;
-
         if (options.organization) {
             user = options.organization;
+            options.type = options.type || Repo.TYPE_ALL;
+        } else {
+            user = options.user;
+            options.type = options.type || Repo.TYPE_OWNER;
         }
 
-        logger.log('Listing ' + logger.colors.green(options.type) + ' repos for ' +
-            logger.colors.green(user));
+        if (options.isTTY.out) {
+            logger.log('Listing ' + logger.colors.green(options.type) + ' repos for ' +
+                logger.colors.green(user));
+        }
+
 
         instance.list(user, function(err) {
             if (err) {
@@ -235,20 +240,18 @@ Repo.prototype.list = function(user, opt_callback) {
     }
 
     if (options.type === 'public' || options.type === 'private') {
-        if (user !== options.user) {
-            logger.error('You can only list public and private repos of your own.');
+        if (user === options.user) {
+            method = 'getAll';
         }
         else {
-            base.github.repos.getAll(payload, function(err, repos) {
-                instance.listCallback_(err, repos, opt_callback);
-            });
+            logger.error('You can only list your own public and private repos of your own.');
+            return;
         }
     }
-    else {
-        base.github.repos[method](payload, function(err, repos) {
-            instance.listCallback_(err, repos, opt_callback);
-        });
-    }
+
+    base.github.repos[method](payload, function(err, repos) {
+        instance.listCallback_(err, repos, opt_callback);
+    });
 };
 
 Repo.prototype.listCallback_ = function(err, repos, opt_callback) {
@@ -281,8 +284,10 @@ Repo.prototype.listCallback_ = function(err, repos, opt_callback) {
                     logger.log('last update ' + logger.getDuration(repo.updated_at));
                 }
 
-                logger.log(logger.colors.green('forks: ' + repo.forks +
-                    ', stars: ' + repo.watchers + ', issues: ' + repo.open_issues) + '\n');
+                if (options.isTTY.out) {
+                    logger.log(logger.colors.green('forks: ' + repo.forks +
+                            ', stars: ' + repo.watchers + ', issues: ' + repo.open_issues) + '\n');
+                }
             }
         }
 


### PR DESCRIPTION
This is a small first step toward making #357 a reality. This starts off by adding isTTY to the options so that commands may print or not some output based on the fact that the content is going to be piped out or not.

Initial implementation of repository listing for piping purposes.
Add a isTTY value on the options to determine whether or not the command is executed in a TTY context or not. Based on this value, output may be printed or not.
Set the default options.type based on whether we're listing a user or an organization repositories.