### PR TITLE
Add the ability to search issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,48 @@ gh is 100
 gh is 100 --browser
     ```
 
+### 6. Search
+
+Option             | Usage        | Type
+---                | ---          | ---
+`-s`, `--search`   | **Required** | `Boolean`
+`-a`, `--all`      | *Optional*   | `Boolean`
+`-d`, `--detailed` | *Optional*   | `Boolean`
+`-r`, `--repo`     | *Optional*   | `String`
+`-u`, `--user`     | *Optional*   | `String`
+
+#### Examples
+
+* Search issues in current repository
+
+    ```
+gh is --search 'term'
+    ```
+
+* Search issues in all repositories for a user
+
+    ```
+gh is --all --user node-gh --search 'term'
+    ```
+
+* Search issues in a repository for a user
+
+    ```
+gh is  --user node-gh --repo gh --search 'term'
+    ```
+
+* Search issues in a repository for a user with link and content
+
+    ```
+gh is  --user node-gh --repo gh --search 'term'
+    ```
+
+* Search issues with github filters
+
+    ```
+gh is  --user node-gh --repo gh --search 'updated:<=2013-05-24'
+    ```
+
 ## Repo
 ```
 gh repo

--- a/lib/cmds/issue.js
+++ b/lib/cmds/issue.js
@@ -41,7 +41,8 @@ Issue.DETAILS = {
         'comment',
         'list',
         'new',
-        'open'
+        'open',
+        'search'
     ],
     options: {
         'all': Boolean,
@@ -60,6 +61,7 @@ Issue.DETAILS = {
         'open': Boolean,
         'remote': String,
         'repo': String,
+        'search': String,
         'state': ['open', 'closed'],
         'title': String,
         'user': String
@@ -79,6 +81,7 @@ Issue.DETAILS = {
         'n': ['--number'],
         'o': ['--open'],
         'r': ['--repo'],
+        's': ['--search'],
         'S': ['--state'],
         't': ['--title'],
         'u': ['--user']
@@ -207,6 +210,30 @@ Issue.prototype.run = function () {
                 logger.log(issue.html_url);
                 afterHooksCallback();
             });
+        });
+    }
+
+    if (options.search) {
+        var repo = options.repo;
+        if (options.all) {
+            repo = undefined;
+            logger.log('Searching for ' + logger.colors.green(options.search) +
+                ' in issues for ' + logger.colors.green(options.user));
+        } else {
+            logger.log('Searching for ' + logger.colors.green(options.search) +
+                ' in issues on ' + logger.colors.green(options.user + '/' + options.repo));
+        }
+
+        instance.search(options.user, repo, function (err) {
+            if (err) {
+                if (options.all) {
+                    logger.error('Can\'t search issues for ' + options.user);
+                    return;
+                } else {
+                    logger.error('Can\'t search issues on ' + options.user + '/' + options.repo);
+                    return;
+                }
+            }
         });
     }
 
@@ -450,6 +477,82 @@ Issue.prototype.open = function (opt_callback) {
         }
         else {
             instance.editIssue_(issue.title, Issue.STATE_OPEN, opt_callback);
+        }
+    });
+};
+
+Issue.prototype.search = function (user, repo, opt_callback) {
+    var instance = this,
+        options = instance.options,
+        operations = [],
+        query = [],
+        payload;
+
+    options.label = options.label || '';
+
+    if (!options.all) {
+        query.push('repo:' + repo);
+    }
+
+    query.push('user:' + user);
+    query.push(options.search);
+    query = query.join('+');
+
+    payload = {
+        q: query,
+        type: 'Issues'
+    };
+
+    operations.push(function (callback) {
+        base.github.search.issues(payload, callback);
+    });
+
+    async.series(operations, function (err, results) {
+        var issues = [];
+
+        if (err && !options.all) {
+            logger.error(logger.getErrorMessage(err));
+        }
+
+        results[0].items.forEach(function (result) {
+            if (result) {
+                issues = issues.concat(result);
+            }
+        });
+
+        issues.sort(function (a, b) {
+            return a.number > b.number ? -1 : 1;
+        });
+
+        if (issues && issues.length > 0) {
+            issues.forEach(function (issue) {
+                var labels = issue.label || [];
+
+                logger.log(logger.colors.green('#' + issue.number) + ' ' + issue.title + ' ' +
+                    logger.colors.magenta('@' + issue.user.login + ' (' + logger.getDuration(issues.created_at) + ')'));
+
+                if (options.detailed) {
+                    if (issue.body) {
+                        logger.log(issue.body);
+                    }
+
+                    labels.forEach(function (label) {
+                        labels.push(label.name);
+                    });
+
+                    if (labels.length > 0) {
+                        logger.log(logger.colors.green('label: ') + labels.join(', '));
+                    }
+
+                    if (issue.milestone) {
+                        logger.log(logger.colors.green('milestone: ') +
+                            issue.milestone.title + ' - ' + issue.milestone.number);
+                    }
+
+                    logger.log(logger.colors.blue(issue.html_url));
+                }
+            });
+            opt_callback && opt_callback(err);
         }
     });
 };


### PR DESCRIPTION
Adds the ability to search issues, including using github filters like `updated:<=2013-05-24`.

Here are the options and examples for the command.

### Search

Option             | Usage        | Type
---                | ---          | ---
`-s`, `--search`   | **Required** | `Boolean`
`-a`, `--all`      | *Optional*   | `Boolean`
`-d`, `--detailed` | *Optional*   | `Boolean`
`-r`, `--repo`     | *Optional*   | `String`
`-u`, `--user`     | *Optional*   | `String`

#### Examples

* Search issues in current repository

    ```
gh is --search 'term'
    ```

* Search issues in all repositories for a user

    ```
gh is --all --user node-gh --search 'term'
    ```

* Search issues in a repository for a user

    ```
gh is  --user node-gh --repo gh --search 'term'
    ```

* Search issues in a repository for a user with link and content

    ```
gh is  --user node-gh --repo gh --search 'term'
    ```

* Search issues with github filters

    ```
gh is  --user node-gh --repo gh --search 'updated:<=2013-05-24'
    ```