### PR TITLE
Fixes error in usage text

### DIFF
--- a/lib/cmds/help.js
+++ b/lib/cmds/help.js
@@ -171,7 +171,7 @@ Help.prototype.listCommands_ = function (commands) {
 
     content += '\n(*) Flags that can execute an action.\n' +
     '\'gh help\' lists available commands.\n' +
-    '\'git help -a\' lists all available subcommands.';
+    '\'gh help -a\' lists all available subcommands.';
 
     return content;
 };


### PR DESCRIPTION
I assume this is meant to say `gh help -a` instead of `git help -a`