### PR TITLE
Don't pull tags on fetching remote branch.

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -65,7 +65,7 @@ exports.push = function (remote, branch) {
 };
 
 exports.fetch = function (repoUrl, headBranch, pullBranch) {
-    var args = ['fetch', repoUrl, headBranch + ':' + pullBranch];
+    var args = ['fetch', repoUrl, headBranch + ':' + pullBranch, '--no-tags'];
 
     return exec.spawnSyncStream(git_command, args);
 };


### PR DESCRIPTION
@dustinryerson reported a crash issue due to too many tags on a given code review program.

By default, `git pull` and `git fetch` fetches tags when invoked.

Too many objects (be it content, commits, tags, or whatever) on a git repository is problematic.