### PR TITLE
adds --link option that prints links to issues and pull requests

### DIFF
--- a/lib/cmds/issue.js
+++ b/lib/cmds/issue.js
@@ -432,8 +432,12 @@ Issue.prototype.list = function (user, repo, opt_callback) {
             issues.forEach(function (issue) {
                 var labels = issue.label || [];
 
-                logger.log(logger.colors.green('#' + issue.number) + ' ' + issue.title + ' ' +
-                    logger.colors.magenta('@' + issue.user.login + ' (' + logger.getDuration(issue.created_at) + ')'));
+                var headline = logger.colors.green('#' + issue.number) + ' ' + issue.title + ' ' +
+                    logger.colors.magenta('@' + issue.user.login + ' (' + logger.getDuration(issue.created_at) + ')');
+                if (options.link) {
+                    headline += ' ' + logger.colors.blue(issue.html_url);
+                }
+                logger.log(headline);
 
                 if (options.detailed) {
                     if (issue.body) {
@@ -453,8 +457,6 @@ Issue.prototype.list = function (user, repo, opt_callback) {
                             issue.milestone.title + ' - ' + issue.milestone.number);
                     }
 
-                    logger.log(logger.colors.blue(issue.html_url));
-                } else if (options.link) {
                     logger.log(logger.colors.blue(issue.html_url));
                 }
             });

--- a/lib/cmds/issue.js
+++ b/lib/cmds/issue.js
@@ -55,6 +55,7 @@ Issue.DETAILS = {
         'detailed': Boolean,
         'label': String,
         'list': Boolean,
+        'link': Boolean,
         'message': String,
         'milestone': [Number, String],
         'no-milestone': Boolean,
@@ -76,6 +77,7 @@ Issue.DETAILS = {
         'c': ['--comment'],
         'd': ['--detailed'],
         'L': ['--label'],
+        'k': ['--link'],
         'l': ['--list'],
         'm': ['--message'],
         'M': ['--milestone'],
@@ -451,6 +453,8 @@ Issue.prototype.list = function (user, repo, opt_callback) {
                             issue.milestone.title + ' - ' + issue.milestone.number);
                     }
 
+                    logger.log(logger.colors.blue(issue.html_url));
+                } else if (options.link) {
                     logger.log(logger.colors.blue(issue.html_url));
                 }
             });

--- a/lib/cmds/pull-request.js
+++ b/lib/cmds/pull-request.js
@@ -65,6 +65,7 @@ PullRequest.DETAILS = {
         'fwd': String,
         'issue': Number,
         'info': Boolean,
+        'link': Boolean,
         'list': Boolean,
         'me': Boolean,
         'merge': Boolean,
@@ -91,6 +92,7 @@ PullRequest.DETAILS = {
         'f': ['--fetch'],
         'i': ['--issue'],
         'I': ['--info'],
+        'k': ['--link'],
         'l': ['--list'],
         'M': ['--merge'],
         'm': ['--me'],
@@ -466,7 +468,7 @@ PullRequest.prototype.printPullInfo_ = function (pull) {
         pull.title + ' ' + logger.colors.magenta('@' + pull.user.login) +
         ' (' + logger.getDuration(pull.created_at) + ')');
 
-    if (options.detailed) {
+    if (options.link || options.detailed) {
         logger.log(logger.colors.blue(pull.html_url));
     }
 

--- a/lib/cmds/pull-request.js
+++ b/lib/cmds/pull-request.js
@@ -464,11 +464,17 @@ PullRequest.prototype.getPullsTemplateJson_ = function (pulls, opt_callback) {
 PullRequest.prototype.printPullInfo_ = function (pull) {
     var options = this.options;
 
-    logger.log(logger.colors.green('#' + pull.number) + ' ' +
+    var headline = logger.colors.green('#' + pull.number) + ' ' +
         pull.title + ' ' + logger.colors.magenta('@' + pull.user.login) +
-        ' (' + logger.getDuration(pull.created_at) + ')');
+        ' (' + logger.getDuration(pull.created_at) + ')';
 
-    if (options.link || options.detailed) {
+    if (options.link) {
+        headline += ' ' + logger.colors.blue(pull.html_url);
+    }
+
+    logger.log(headline);
+
+    if (options.detailed && !options.link) {
         logger.log(logger.colors.blue(pull.html_url));
     }
 


### PR DESCRIPTION
The `--link` option is similar to `--detailed` except that it won't display the body of the issues.

Personally, I'm interested in this because I use iTerm, and it allows urls printed to the terminal to be clicked and open in my browser.

As a side note, I think it would be really amazing to introduce a feature like git's `--pretty=format`