### PR TITLE
Fix markdown codeblock syntax so the README renders as intended

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,15 @@ gh help
 
 * List all comands options.
 
-    ```
+```
 gh help --all
-    ```
+```
 
 * List specific command options.
 
-    ```
+```
 gh help <command>
-    ```
+```
 
 ### Global flags
 Option            | Usage        | Type
@@ -112,63 +112,63 @@ Option            | Usage        | Type
 
 * **Shortcut** for listing open pull requests for the current repository.
 
-    ```
+```
 gh pr
-    ```
+```
 
 * Get information about a pull request.
 
-    ```
+```
 gh pr --info number
-    ```
+```
 
 * List open pull requests for all branches from all your repositories.
 
-    ```
+```
 gh pr --list --all
-    ```
+```
 
 * List open pull requests for all branches in all repositories belonging to the "github" organization.
 
-    ```
+```
 gh pr --list --all --org github
-    ```
+```
 
 * List open pull requests sent by logged user on current repository.
 
-    ```
+```
 gh pr --list --me
-    ```
+```
 
 * List open pull requests with link and content.
 
-    ```
+```
 gh pr --list --detailed
-    ```
+```
 
 * List open pull requests for a branch.
 
-    ```
+```
 gh pr --list --branch master
-    ```
+```
 
 * List open pull requests and sort them by popularity *(comment count)*.
 
-    ```
+```
 gh pr --list --sort popularity
-    ```
+```
 
 * List open pull requests and sort them by asc long-running *(old but still active)*.
 
-    ```
+```
 gh pr --list --sort long-running --direction asc
-    ```
+```
 
 * List open pull requests and sort them by complexity *(complexity is calculated based on number of additions, deletions, changed files, comments and review comments)*.
 
-    ```
+```
 gh pr --list --sort complexity
-    ```
+```
 
 ### 3. Fetch
 
@@ -186,18 +186,18 @@ Option           | Usage        | Type
 
 * **Shortcut** for fetching pull request and checkout into a new branch `pr-1`.
 
-    ```
+```
 gh pr 1
-    ```
+```
 
 * Fech pull request rebasing or merging into the current branch.
 
-    ```
+```
 gh pr 1 --fetch --rebase
-    ```
-    ```
+```
+```
 gh pr 1 --fetch --merge
-    ```
+```
 
 ### 4. Merge or rebase
 
@@ -217,23 +217,23 @@ Omitting `--number` will try to guess the pull number from branch name e.g. `pr-
 
 * Merge or rebase pull request into a branch.
 
-    ```
+```
 gh pr 1 --fetch --merge
-    ```
+```
 
-    ```
+```
 gh pr 1 --fetch --rebase
-    ```
+```
 
 * Merge or rebase pull request into branch `dev`.
 
-    ```
+```
 gh pr 1 --fetch --rebase --branch dev
-    ```
+```
 
-    ```
+```
 gh pr 1 --fetch --merge --branch dev
-    ```
+```
 
 ### 5. Comment
 
@@ -249,9 +249,9 @@ Option           | Usage        | Type
 
 * Comment on a pull request.
 
-    ```
+```
 gh pr 1 --comment "Merged, thank you!"
-    ```
+```
 
 ### 6. Forward
 
@@ -267,9 +267,9 @@ in your [config file](#config).
 
 * Forward a pull request to another reviewer.
 
-    ```
+```
 gh pr 1 --fwd username
-    ```
+```
 
 ### 7. Open or close
 
@@ -286,32 +286,32 @@ Option           | Usage        | Type
 
 * Open a pull request.
 
-    ```
+```
 gh pr 1 --open
-    ```
+```
 * Close a pull request.
 
-    ```
+```
 gh pr 1 --close
-    ```
+```
 
 * Close multiple pull requests.
 
-    ```
+```
 gh pr --close --number 1 --number 2
-    ```
+```
 
 * Open multiple pull requests.
 
-    ```
+```
 gh pr --open --number 1 --number 2
-    ```
+```
 
 * Open or close a pull request that you've sent to someone.
 
-    ```
+```
 gh pr 1 --close --user eduardolundgren
-    ```
+```
 
 ### 8. Submit
 
@@ -332,21 +332,21 @@ using the last commit message as title.
 
 * Submit a pull request using the current branch.
 
-    ```
+```
 gh pr --submit eduardolundgren --title 'Fix #32' --description 'Awesome fix'
-    ```
+```
 
 * Submit a pull request using the current branch to dev branch.
 
-    ```
+```
 gh pr --submit eduardolundgren --branch dev
-    ```
+```
 
 * Submit a pull request from a issue.
 
-    ```
+```
 gh pr --submit eduardolundgren --issue 150
-    ```
+```
 
 ### 9. Open in Browser
 
@@ -361,9 +361,9 @@ Option                 | Usage        | Type
 
 * Open GitHub pull request page in the browser.
 
-    ```
+```
 gh pr 100 --browser
-    ```
+```
 
 ## Notifications
 
@@ -387,15 +387,15 @@ Option           | Usage        | Type
 
 * **Shortcut** for displaying the latest activities on the current repository.
 
-    ```
+```
 gh nt
-    ```
+```
 
 * Display the latest activities on a certain repository.
 
-    ```
+```
 gh nt --latest --user eduardolundgren --repo node-gh
-    ```
+```
 
 ### 2. Watch
 
@@ -410,15 +410,15 @@ Option           | Usage        | Type
 
 * Watch for any activity on the current repository.
 
-    ```
+```
 gh nt --watch
-    ```
+```
 
 * Watch for any activity on a certain repository.
 
-    ```
+```
 gh nt --watch --user eduardolundgren --repo node-gh
-    ```
+```
 
 ## Issues
 
@@ -445,27 +445,27 @@ Option            | Usage        | Type
 
 * **Shortcut** for creating a new issue on the current repository.
 
-    ```
+```
 gh is 'Node GH rocks!' 'Body with **Markdown** support'
-    ```
+```
 
 * Create a new issue on a certain repository.
 
-    ```
+```
 gh is --new --title 'Node GH rocks!' --message 'Body with **Markdown** support' --user eduardolundgren --repo node-gh
-    ```
+```
 
 * Create a new issue with labels.
 
-    ```
+```
 gh is --new --title 'Node GH rocks!' --label bug,question,test
-    ```
+```
 
 * Create a new issue and assign it to someone.
 
-    ```
+```
 gh is --new --title 'Node GH rocks!' --assignee zenorocha
-    ```
+```
 
 ### 2. Comment
 
@@ -481,15 +481,15 @@ Option            | Usage        | Type
 
 * Comment on an issue of the current repository.
 
-    ```
+```
 gh is 1 --comment 'Node GH rocks!'
-    ```
+```
 
 * Comment on an issue of a certain repository.
 
-    ```
+```
 gh is 1 --comment 'Node GH rocks!' --user eduardolundgren --repo node-gh
-    ```
+```
 
 ### 3. Open or close
 
@@ -506,32 +506,32 @@ Option           | Usage        | Type
 
 * Open an issue.
 
-    ```
+```
 gh is 1 --open
-    ```
+```
 * Close an issue.
 
-    ```
+```
 gh is 1 --close
-    ```
+```
 
 * Close multiple issues.
 
-    ```
+```
 gh is --close --number 1 --number 2
-    ```
+```
 
 * Open multiple issues.
 
-    ```
+```
 gh is --open --number 1 --number 2
-    ```
+```
 
 * Open or close an issue that you've sent to someone.
 
-    ```
+```
 gh is 1 --close --user eduardolundgren
-    ```
+```
 
 ### 4. List
 
@@ -552,51 +552,51 @@ Option             | Usage        | Type
 
 * **Shortcut** for listing all issues on the current repository.
 
-    ```
+```
 gh is
-    ```
+```
 
 * List all issues from all repositories.
 
-    ```
+```
 gh is --list --all
-    ```
+```
 
 * List issues assigned to someone.
 
-    ```
+```
 gh is --list --assignee zenorocha
-    ```
+```
 
 * List issues with link and content.
 
-    ```
+```
 gh is --list --detailed
-    ```
+```
 
 * List only closed issues on the current repository.
 
-    ```
+```
 gh is --list --state closed
-    ```
+```
 
 * List issues filtered by milestone.
 
-    ```
+```
 gh is --list --milestone 1
-    ```
+```
 
 * List issues that contains labels `todo` and `bug`.
 
-    ```
+```
 gh is --list --label todo,bug
-    ```
+```
 
 * List all issues on a certain repository.
 
-    ```
+```
 gh is --list --user eduardolundgren --repo node-gh
-    ```
+```
 
 ### 5. Open in Browser
 
@@ -610,15 +610,15 @@ Option                 | Usage        | Type
 #### Examples
 
 * **Shortcut** for opening GitHub issue page in the browser.
-    ```
+```
 gh is 100
-    ```
+```
 
 * Open GitHub issue page in the browser.
 
-    ```
+```
 gh is 100 --browser
-    ```
+```
 
 ### 6. Search
 
@@ -634,33 +634,33 @@ Option             | Usage        | Type
 
 * Search issues in current repository
 
-    ```
+```
 gh is --search 'term'
-    ```
+```
 
 * Search issues in all repositories for a user
 
-    ```
+```
 gh is --all --user node-gh --search 'term'
-    ```
+```
 
 * Search issues in a repository for a user
 
-    ```
+```
 gh is  --user node-gh --repo gh --search 'term'
-    ```
+```
 
 * Search issues in a repository for a user with link and content
 
-    ```
+```
 gh is  --user node-gh --repo gh --search 'term'
-    ```
+```
 
 * Search issues with github filters
 
-    ```
+```
 gh is  --user node-gh --repo gh --search 'updated:<=2013-05-24'
-    ```
+```
 
 ### 7. Assign
 
@@ -676,15 +676,15 @@ Option            | Usage        | Type
 
 * Assign an issue on the current repository to a user.
 
-    ```
+```
 gh is --assign --assignee zenorocha --number 1
-    ```
+```
 
 * Assign an issue on a specific repository to a user.
 
-    ```
+```
 gh is --assign --assignee zenorocha --number 1 --user eduardolundgren --repo gh
-    ```
+```
 
 ## Repo
 ```
@@ -705,15 +705,15 @@ Option                 | Usage        | Type
 
 * **Shortcut** for opening the GitHub repository page in the browser.
 
-    ```
+```
 gh re
-    ```
+```
 
 * Open GitHub repository page in the browser.
 
-    ```
+```
 gh re --browser --user eduardolundgren --repo node-gh
-    ```
+```
 
 ### 2. List
 
@@ -728,21 +728,21 @@ Option                 | Usage        | Type
 
 * List all repositories.
 
-    ```
+```
 gh re --list
-    ```
+```
 
 * List all private repositories.
 
-    ```
+```
 gh re --list --type private
-    ```
+```
 
 * List all repositories from someone.
 
-    ```
+```
 gh re --list --user zenorocha
-    ```
+```
 
 ### 3. Create
 
@@ -761,27 +761,27 @@ Option                | Usage        | Type
 
 * Create a new GitHub repository and clone on the current directory.
 
-    ```
+```
 gh re --new foo --clone
-    ```
+```
 
 * Create a new GitHub repository for an organization.
 
-    ```
+```
 gh re --new foo --organization node-gh
-    ```
+```
 
 * Create a new GitHub repository using .gitignore template for Ruby.
 
-    ```
+```
 gh re --new gemified --gitignore Ruby
-    ```
+```
 
 * Create a new private repository on GitHub, initializing it with a initial commit of the README.
 
-    ```
+```
 gh re --new foo --init --type private
-    ```
+```
 
 ### 4. Fork
 
@@ -795,15 +795,15 @@ Option                | Usage        | Type
 
 * Fork a GitHub repository.
 
-    ```
+```
 gh re --fork repo --user user
-    ```
+```
 
 * Fork a GitHub repository into the node-gh organization.
 
-    ```
+```
 gh re --fork repo --user user --organization node-gh
-    ```
+```
 
 ### 5. Delete
 
@@ -816,9 +816,9 @@ Option                | Usage        | Type
 
 * Delete a repository of the logged user.
 
-    ```
+```
 gh re --delete foo
-    ```
+```
 
 ### 6. Clone
 
@@ -834,15 +834,15 @@ Option                | Usage        | Type
 
 * Clone a repository.
 
-    ```
+```
 gh re --clone --repo gh
-    ```
+```
 
 * Clone a repository from a specific user using HTTPS protocol.
 
-    ```
+```
 gh re --clone --user eduardolundgren --repo gh --protocol https
-    ```
+```
 
 ### 7. Create Label
 
@@ -859,15 +859,15 @@ Option                | Usage        | Type
 
 * Create a label for a repository.
 
-    ```
+```
 gh re --label --new bug --color color --repo gh
-    ```
+```
 
 * Create a label for a user's repository.
 
-    ```
+```
 gh re --label --new bug --color color --user eduardolundgren --repo gh
-    ```
+```
 
 ### 8. Delete Label
 
@@ -883,15 +883,15 @@ Option                | Usage        | Type
 
 * Delete a label from a repository.
 
-    ```
+```
 gh re --label --delete bug --repo gh
-    ```
+```
 
 * Delete a label from a user's repository.
 
-    ```
+```
 gh re --label --delete bug --user eduardolundgren --repo gh
-    ```
+```
 
 ### 9. List Labels
 
@@ -907,15 +907,15 @@ Option                | Usage        | Type
 
 * List labels for a repository.
 
-    ```
+```
 gh re --label --list --repo gh
-    ```
+```
 
 * List labels for a user's repository.
 
-    ```
+```
 gh re --label --list --user eduardolundgren --repo gh
-    ```
+```
 
 ### 10. Update Label
 
@@ -932,15 +932,15 @@ Option                | Usage        | Type
 
 * Update a label for a repository.
 
-    ```
+```
 gh re --label --update bug --color color --repo gh
-    ```
+```
 
 * Update a label for a user's repository.
 
-    ```
+```
 gh re --label --update bug --color color --user eduardolundgren --repo gh
-    ```
+```
 
 ## Gists
 
@@ -962,15 +962,15 @@ Option                 | Usage        | Type
 
 * **Shortcut** for opening your Gists in the browser.
 
-    ```
+```
 gh gi
-    ```
+```
 
 * Open a Gist in the browser.
 
-    ```
+```
 gh gi --browser --id 5991877
-    ```
+```
 
 ### 2. List
 
@@ -983,15 +983,15 @@ Option                 | Usage        | Type
 
 * List all gists.
 
-    ```
+```
 gh gi --list
-    ```
+```
 
 * List all gists from someone.
 
-    ```
+```
 gh gi --list --user brunocoelho
-    ```
+```
 
 ### 3. Create
 
@@ -1006,15 +1006,15 @@ Option                | Usage        | Type
 
 * Create a Gist `hello` containing "Hello World".
 
-    ```
+```
 gh gi --new hello --content "Hello World!"
-    ```
+```
 
 * Create a private Gist `hello` containing "Hello World".
 
-    ```
+```
 gh gi --new hello --content "Hello World!" --private
-    ```
+```
 
 
 ### 4. Fork
@@ -1027,9 +1027,9 @@ Option                | Usage        | Type
 
 * Fork a Gist.
 
-    ```
+```
 gh gi --fork 5444883
-    ```
+```
 
 
 ### 5. Delete
@@ -1042,15 +1042,15 @@ Option                | Usage        | Type
 
 * Delete a Gist.
 
-    ```
+```
 gh gi --delete 4252323
-    ```
+```
 
 * Delete multiple Gists.
 
-    ```
+```
 gh gi --delete 4252321 --delete 4252322
-    ```
+```
 
 ## User
 
@@ -1071,15 +1071,15 @@ Option            | Usage        | Type
 
 * Login or show current logged in GitHub user.
 
-    ```
+```
 gh user --login
-    ```
+```
 
 * Logout current GitHub account.
 
-    ```
+```
 gh user --logout
-    ```
+```
 
 ### 2. Whoami
 
@@ -1091,9 +1091,9 @@ Option             | Usage        | Type
 
 * Prints your username to stdout.
 
-    ```
+```
 gh user --whoami
-    ```
+```
 
 ## Alias
 
@@ -1113,15 +1113,15 @@ Option            | Usage        | Type
 
 * **Shortcut** for listing aliases.
 
-    ```
+```
 gh alias
-    ```
+```
 
 * List aliases.
 
-    ```
+```
 gh alias --list
-    ```
+```
 
 ### 2. Add
 
@@ -1134,9 +1134,9 @@ Option            | Usage        | Type
 
 * Create alias for username.
 
-    ```
+```
 gh alias --add zeno --user zenorocha
-    ```
+```
 
 ### 3. Remove
 
@@ -1148,9 +1148,9 @@ Option            | Usage        | Type
 
 * Remove alias.
 
-    ```
+```
 gh alias --remove zeno
-    ```
+```
 
 ## Config
 
@@ -1161,39 +1161,39 @@ You can also set per-project configurations by adding a `.gh.json` file in your 
 
 * GitHub API configurations. Change it if you're a [GitHub Enterprise](https://enterprise.github.com/) user.
 
-    ```javascript
+```javascript
 "api": {
     "host": "api.github.com",
     "protocol": "https",
     "version": "3.0.0",
     "pathPrefix": null
 }
-    ```
+```
 
 * Set default branch and remote.
 
-    ```javascript
+```javascript
 "default_branch": "master",
 "default_remote": "origin"
-    ```
+```
 
 * Set default users when [submitting](#7-submit) or [forwarding](#5-forward) pull requests.
 
-    ```javascript
+```javascript
 "default_pr_forwarder": "",
 "default_pr_reviewer": ""
-    ```
+```
 
 * GitHub data filled once you log in.
 
-    ```javascript
+```javascript
 "github_token": "",
 "github_user": ""
-    ```
+```
 
 * Run automated tasks before or after a certain command.
 
-    ```javascript
+```javascript
 "hooks": {
         "pull-request": {
             "merge": {
@@ -1204,11 +1204,11 @@ You can also set per-project configurations by adding a `.gh.json` file in your 
             }
         }
 }
-    ```
+```
 
 * Run automated tasks passing arguments to the commands. Required for prompt commands.
 
-    ```javascript
+```javascript
 "hooks": {
         "pull-request": {
             "merge": {
@@ -1216,19 +1216,19 @@ You can also set per-project configurations by adding a `.gh.json` file in your 
             }
         }
 }
-    ```
+```
 
 * Set default branch name prefix for PR fetching.
 
-    ```javascript
+```javascript
 "pull_branch_name_prefix": "pr-"
-    ```
+```
 
 * Insert signature below issue comment.
 
-    ```javascript
+```javascript
 "signature": "<br><br>:octocat: *Sent from [GH](http://nodegh.io).*"
-    ```
+```
 
 If you need to use a custom git command, set the environment variable `GH_GIT_COMMAND`.
 


### PR DESCRIPTION
The README for this project has a ton of syntax errors, so the rendered result
on Github itself is ugly and confusing! This simple update fixes most of them.