### PR TITLE
Set FORCE_COLOR=true as environment variable on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
     - "6"
     - "8"
 sudo: false
+env:
+    - FORCE_COLOR=true
 before_install:
     - sh ci.sh
 script:


### PR DESCRIPTION
Looks like CI on master branch has issue with color display, maybe we could force enable it to prevent the test failed.