### PR TITLE
PR List: replace special characters with string which can be parsed

### DIFF
--- a/lib/cmds/pull-request.js
+++ b/lib/cmds/pull-request.js
@@ -469,10 +469,10 @@ PullRequest.prototype.printPullInfo_ = function(pull) {
 
     switch (pull.combinedStatus) {
         case 'success':
-            status = logger.colors.green(' ✓')
+            status = logger.colors.green(' OK')
             break
         case 'failure':
-            status = logger.colors.red(' ✗')
+            status = logger.colors.red(' NOK')
             break
     }
 


### PR DESCRIPTION
when issuing `gh pr --list`, I could not easily parse PR test status because of special characters that were used. I understand this is probably an issue with my terminal.
Yet, with this PR, I can programmatically parse the status, looking for `OK` / `NOK` strings. 

Before:
![image](https://user-images.githubusercontent.com/5385290/37040587-82bfaecc-215a-11e8-869a-c2780ea23384.png)

With the change:
![image](https://user-images.githubusercontent.com/5385290/37040389-04eb57c6-215a-11e8-885d-84bbeaa15a86.png)

It still looks nice thanks to the coloring.

