### PR TITLE
Fixes errors happening when '--no-hooks' was given.

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -14,6 +14,7 @@ var async = require('async'),
     exec = require('./exec'),
     truncate = require('truncate'),
     logger = require('./logger'),
+    lodash = require('lodash'),
     config = configs.getConfig(true)
 
 exports.createContext = function(scope) {
@@ -76,7 +77,7 @@ exports.invoke = function(path, scope, opt_callback) {
         context
 
     if (options.hooks === false || process.env.NODEGH_HOOK_IS_LOCKED) {
-        opt_callback && opt_callback()
+        opt_callback && opt_callback(lodash.noop)
         return
     }
 


### PR DESCRIPTION
First of all, let me start by saying great job on Node GH!
It's a real lifesaver for me and my team!

I've noticed a small bug though:
When the `--no-hooks` flag is given, Node-GH sometimes resolves in an error.

For example:
`gh pr 1 --no-hooks --fetch --merge --branch my-branch`

Will result in:
```
TypeError: afterHooksCallback is not a function
    at /Users/jeffrey/.nvm/versions/node/v8.9.4/lib/node_modules/gh/lib/cmds/pull-request.js:868:13
    at /Users/jeffrey/.nvm/versions/node/v8.9.4/lib/node_modules/gh/lib/cmds/pull-request.js:346:9
    at /Users/jeffrey/.nvm/versions/node/v8.9.4/lib/node_modules/gh/node_modules/github/api/v3.0.0/pullRequests.js:118:17
    at callCallback (/Users/jeffrey/.nvm/versions/node/v8.9.4/lib/node_modules/gh/node_modules/github/index.js:743:17)
    at IncomingMessage.<anonymous> (/Users/jeffrey/.nvm/versions/node/v8.9.4/lib/node_modules/gh/node_modules/github/index.js:796:25)
    at emitNone (events.js:111:20)
    at IncomingMessage.emit (events.js:208:7)
    at endReadableNT (_stream_readable.js:1055:12)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```

I have simply passed a `lodash.noop` on the `opt_callback()` in `lib/hooks.js` to fix this issue.
I think it's good solution because `opt_callback` always expects a callback anyway.

Let me know if you want me to make any tweaks, I will see if I have time to implement them!
