### PR TITLE
fixed display of labels (they hadn’t been displaying)

### DIFF
--- a/lib/cmds/issue.js
+++ b/lib/cmds/issue.js
@@ -450,7 +450,7 @@ Issue.prototype.list = function(user, repo, opt_callback) {
 
         if (issues && issues.length > 0) {
             issues.forEach(function(issue) {
-                var labels = issue.label || []
+                var labels = issue.labels || []
 
                 var headline =
                     logger.colors.green('#' + issue.number) +
@@ -470,12 +470,16 @@ Issue.prototype.list = function(user, repo, opt_callback) {
                         logger.log(issue.body)
                     }
 
+                    var labelsForDisplay = []
                     labels.forEach(function(label) {
-                        labels.push(label.name)
+                        labelsForDisplay.push(label.name)
                     })
 
-                    if (labels.length > 0) {
-                        logger.log(logger.colors.green('label: ') + labels.join(', '))
+                    if (labelsForDisplay.length > 0) {
+                        var labelLabel = labelsForDisplay.length > 1 ? 'labels' : 'label'
+                        logger.log(
+                            logger.colors.yellow(labelLabel + ': ') + labelsForDisplay.join(', ')
+                        )
                     }
 
                     if (issue.milestone) {


### PR DESCRIPTION
fixes #540.  There was a bug in the `labels` var assignment in cmds/issue.js , from the nonexistent attribute `issue.label`, fixed with `issue.labels`.  Further down, the `labels` array was pushed to from iterating on itself with `label.name`, rather than making a fresh array of label strings for display.  Finally, made a distinctive color for issue display and displayed the appropriate singular/plural of 'label'.