### PR TITLE
GH attempts to link a PR to the wrong remote branch name when the local branch name contains 'pr-'

### DIFF
--- a/lib/cmds/pull-request.js
+++ b/lib/cmds/pull-request.js
@@ -19,7 +19,8 @@ var async = require('async'),
     logger = require('../logger'),
     openUrl = require('opn'),
     Issues = require('./issue').Impl,
-    config = base.getConfig()
+    config = base.getConfig(),
+    _ = require('lodash')
 
 // -- Constructor ----------------------------------------------------------------------------------
 
@@ -425,7 +426,7 @@ PullRequest.prototype.getPullRequestNumberFromBranch_ = function() {
 
     prefix = config.pull_branch_name_prefix
 
-    if (options.currentBranch && options.currentBranch.indexOf(prefix) > -1) {
+    if (options.currentBranch && _.startsWith(options.currentBranch, prefix)) {
         return options.currentBranch.replace(prefix, '')
     }
 }

--- a/lib/cmds/pull-request.js
+++ b/lib/cmds/pull-request.js
@@ -139,7 +139,12 @@ PullRequest.prototype.run = function() {
 
     instance.config = config
 
-    options.number = options.number || instance.getPullRequestNumberFromBranch_()
+    options.number =
+        options.number ||
+        instance.getPullRequestNumberFromBranch_(
+            options.currentBranch,
+            config.pull_branch_name_prefix
+        )
     options.pullBranch = instance.getBranchNameFromPullNumber_(options.number)
     options.state = options.state || PullRequest.STATE_OPEN
 
@@ -419,15 +424,9 @@ PullRequest.prototype.getBranchNameFromPullNumber_ = function(number) {
     }
 }
 
-PullRequest.prototype.getPullRequestNumberFromBranch_ = function() {
-    var instance = this,
-        options = instance.options,
-        prefix
-
-    prefix = config.pull_branch_name_prefix
-
-    if (options.currentBranch && _.startsWith(options.currentBranch, prefix)) {
-        return options.currentBranch.replace(prefix, '')
+PullRequest.prototype.getPullRequestNumberFromBranch_ = function(currentBranch, prefix) {
+    if (currentBranch && _.startsWith(currentBranch, prefix)) {
+        return currentBranch.replace(prefix, '')
     }
 }
 

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -14,8 +14,8 @@ var async = require('async'),
     exec = require('./exec'),
     truncate = require('truncate'),
     logger = require('./logger'),
-    lodash = require('lodash'),
-    config = configs.getConfig(true)
+    config = configs.getConfig(true),
+    _ = require('lodash')
 
 exports.createContext = function(scope) {
     return {
@@ -77,7 +77,7 @@ exports.invoke = function(path, scope, opt_callback) {
         context
 
     if (options.hooks === false || process.env.NODEGH_HOOK_IS_LOCKED) {
-        opt_callback && opt_callback(lodash.noop)
+        opt_callback && opt_callback(_.noop)
         return
     }
 

--- a/lib/rest-api-client.js
+++ b/lib/rest-api-client.js
@@ -18,14 +18,14 @@ function _classCallCheck(instance, Constructor) {
 var _request = require('request')
 var http = require('http')
 var _url = require('url')
-var lodash = require('lodash')
+var _ = require('lodash')
 var logger = require('./logger')
 
 var RestApiClient = (function() {
     function RestApiClient(options) {
         _classCallCheck(this, RestApiClient)
 
-        options = lodash.merge(this.DEFAULT_CONFIG, options)
+        options = _.merge(this.DEFAULT_CONFIG, options)
         this.options = options
     }
 
@@ -80,7 +80,7 @@ var RestApiClient = (function() {
         }
 
         if (params) {
-            p = lodash.merge(p, params)
+            p = _.merge(p, params)
         }
 
         this.authorize(p)

--- a/test/pull-request.js
+++ b/test/pull-request.js
@@ -104,4 +104,11 @@ describe('Pull Requests Module Tests', function() {
             pr.get('liferay', 'senna.js', '78')
         })
     })
+
+    it('should only get the issue number from a properly prefixed branch', function() {
+        var pr = new pullRequest.Impl({ repo: 'senna.js' })
+
+        assert.equal(pr.getPullRequestNumberFromBranch_('pr-12345', 'pr-'), '12345')
+        assert.equal(pr.getPullRequestNumberFromBranch_('abcpr-12345', 'pr-'), undefined)
+    })
 })


### PR DESCRIPTION
I'm working on a set of changes where the branches are prefixed with `gdpr-*`, and whenever I try to submit a PR with one of these branches, I get the following error:

```
error: src refspec pr-gdLPS-84401-roles-uad does not match any.
error: failed to push some refs to 'git@github.com:drewbrokke/liferay-portal-ee.git'
/usr/local/lib/node_modules/gh/lib/exec.js:53
        throw err
        ^

Error: Child process terminated with error code 1
    at Object.exports.spawnSyncStream (/usr/local/lib/node_modules/gh/lib/exec.js:49:15)
    at Object.exports.push (/usr/local/lib/node_modules/gh/lib/git.js:62:17)
    at /usr/local/lib/node_modules/gh/lib/cmds/pull-request.js:770:17
    at /usr/local/lib/node_modules/gh/node_modules/async/lib/async.js:718:13
    at iterate (/usr/local/lib/node_modules/gh/node_modules/async/lib/async.js:262:13)
    at async.forEachOfSeries.async.eachOfSeries (/usr/local/lib/node_modules/gh/node_modules/async/lib/async.js:281:9)
    at _parallel (/usr/local/lib/node_modules/gh/node_modules/async/lib/async.js:717:9)
    at Object.async.series (/usr/local/lib/node_modules/gh/node_modules/async/lib/async.js:739:9)
    at PullRequest.submit (/usr/local/lib/node_modules/gh/lib/cmds/pull-request.js:799:11)
    at /usr/local/lib/node_modules/gh/lib/cmds/pull-request.js:1051:18
```

The local branch name is: `gdpr-LPS-84401-roles-uad`
And GH attempts to link to: `pr-gdLPS-84401-roles-uad`