### PR TITLE
[WIP] Add search feature to repo command

### DIFF
--- a/README.md
+++ b/README.md
@@ -958,6 +958,41 @@ gh re --label --update bug --color color --repo gh
 gh re --label --update bug --color color --user eduardolundgren --repo gh
 ```
 
+### 11. Search
+
+Search repositories for the terms in name, description or readme.
+You can filter the results using GitHub's [search qualifiers](https://help.github.com/articles/searching-for-repositories/)
+
+| Option             | Usage        | Type                                            |
+| ------------------ | ------------ | ----------------------------------------------- |
+| `-s`, `--search`   | **Required** | `Boolean`                                       |
+| `-d`, `--detailed` | _Optional_   | `Boolean`                                       |
+| `-u`, `--user`     | _Optional_   | `String`                                        |
+| `-t`, `--type`     | _Optional_   | [`all`, `owner`, `public`, `private`, `member`] |
+
+#### Examples
+
+-   Search private repositories you have access to with the term "framework".
+
+```
+gh re --search framework --type private
+```
+or
+```
+gh re --search framework is:private
+```
+
+-   Search for repositories mentioning "hapi" on tokilabs organization and show detailed info
+
+```
+gh re -d -o tokilabs --search hapi
+```
+or
+```
+gh re -d --search hapi org:tokilabs
+```
+
+
 ## Gists
 
 ```

--- a/lib/cmds/repo.js
+++ b/lib/cmds/repo.js
@@ -29,7 +29,7 @@ function Repo(options) {
 Repo.DETAILS = {
     alias: 're',
     description: 'Provides a set of util commands to work with Repositories.',
-    commands: ['browser', 'clone', 'delete', 'fork', 'list', 'new', 'update'],
+    commands: ['browser', 'clone', 'delete', 'fork', 'list', 'new', 'update', 'search'],
     options: {
         browser: Boolean,
         clone: Boolean,
@@ -50,6 +50,7 @@ Repo.DETAILS = {
         private: Boolean,
         protocol: String,
         repo: String,
+        search: String,
         type: ['all', 'forks', 'member', 'owner', 'public', 'private', 'sources'],
         update: String,
         user: String,
@@ -68,6 +69,7 @@ Repo.DETAILS = {
         p: ['--private'],
         P: ['--protocol'],
         r: ['--repo'],
+        s: ['--search'],
         t: ['--type'],
         U: ['--update'],
         u: ['--user'],
@@ -330,6 +332,31 @@ Repo.prototype.run = function() {
         })
     }
 
+    if (options.search) {
+        if (options.organization) {
+            user = options.organization
+            options.type = options.type || Repo.TYPE_ALL
+        } else {
+            user = options.user
+            options.type = options.type || Repo.TYPE_OWNER
+        }
+
+        if (options.isTTY.out) {
+            logger.log(
+                'Searching ' +
+                    logger.colors.green(options.type) +
+                    ' repos in ' +
+                    logger.colors.green(user)
+            )
+        }
+
+        instance.search(user, function(err) {
+            if (err) {
+                logger.error("Can't list repos.")
+            }
+        })
+    }
+
     if (options.new && !options.label) {
         hooks.invoke('repo.new', instance, function(afterHooksCallback) {
             options.repo = options.new
@@ -498,6 +525,45 @@ Repo.prototype.listCallback_ = function(err, repos, opt_callback) {
 
         opt_callback && opt_callback(err)
     }
+}
+
+Repo.prototype.search = function(user, opt_callback) {
+    var instance = this,
+        options = instance.options,
+        terms = [options.search],
+        payload
+
+    // @fix currently options.user is always set, so I'm checking argv
+    if (options.argv.original.some(arg => arg === '-u' || arg === '--user')) {
+        terms.push(`user:${options.user}`)
+    }
+
+    if (options.organization) {
+        terms.push(`org:${options.organization}`)
+    }
+
+    if (options.type === 'public' || options.type === 'private') {
+        terms.push(`is:${options.type}`)
+        delete options.type
+    }
+
+    // add remaining search terms
+    terms = terms.concat(options.argv.remain.slice(1))
+
+    payload = {
+        q: terms.join(' '),
+        // type: options.type,
+        user: user,
+        per_page: 100,
+    }
+
+    base.github.search.repos(payload, function(err, repos) {
+        // console.log(repos)
+        // process.exit()
+        // const re = new RegExp(options.search, 'i')
+        // repos = repos.filter(r => re.test(r.name))
+        instance.listCallback_(err, repos.items.slice(0, 10), opt_callback)
+    })
 }
 
 Repo.prototype.listLabels = function(user, opt_callback) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "gh",
-    "version": "1.13.3",
+    "version": "1.13.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
Hey there, I constantly search for repos on GH because the org I work for has literally hundreds of them with odd names :/

So I found out about nodegh today (which is awesome btw!) but grepping the result of list was too slow, so I decided to add the search option.

The feature is incomplete, needs docs, but I decided to share sooner so you guys can check and tell me if I'm going in the right direction ;)

Btw, options.user is **always** set. So for now I had to use a workaround to detect if the user passed it or not [here](https://github.com/tokilabs/gh/commit/dfc787a5fedb776cc22a3a7f4388767712b0e03b#diff-5b0afcc99bb531dfe82e0ff9b3d4b9bcR537)

This will close #451 when it's done