### PR TITLE
Add config to turn off open editor feature

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,15 +9,7 @@
             "type": "node",
             "request": "launch",
             "runtimeArgs": ["-r", "ts-node/register"],
-            "args": [
-                "${workspaceFolder}/src/debug.ts",
-                "pr",
-                "-s",
-                "protoEvangleion",
-                "--title",
-                "dont ask",
-                "--description"
-            ],
+            "args": ["${workspaceFolder}/src/debug.ts", "is", "--new"],
             // "args": ["${workspaceFolder}/src/debug.ts", "ji", "LWM-117", "--status"],
             "console": "integratedTerminal"
         },

--- a/README.md
+++ b/README.md
@@ -517,6 +517,8 @@ gh pr 1 --comment "Merged, thank you!"
 
 Submit a pull request using your default git editor (`git config --global core.editor`) by passing an empty `--comment`
 
+-   To disable this functionality of opening your editor add `"use_editor": false` to `~/.gh.json`
+
 ```
 gh pr 1 --comment
 ```
@@ -606,6 +608,8 @@ gh pr --submit eduardolundgren --title 'Fix #32' --description 'Awesome fix'
 ```
 
 Submit a pull request using your default git editor (`git config --global core.editor`) by passing an empty `--title` and or `--description`
+
+-   To disable this functionality of opening your editor add `"use_editor": false` to `~/.gh.json`
 
 ```
 gh pr --submit eduardolundgren --title --description
@@ -738,6 +742,8 @@ gh is 'Node GH rocks!' 'Body with **Markdown** support'
 
 Create a new issue using your default git editor (`git config --global core.editor`) by passing an empty `--message` (_also works with an empty title_)
 
+-   To disable this functionality of opening your editor add `"use_editor": false` to `~/.gh.json`
+
 ```
 gh is --new --title 'Node GH rocks!' --message
 ```
@@ -779,6 +785,8 @@ gh is 1 --comment 'Node GH rocks!'
 ```
 
 Comment on an issue using your default git editor (`git config --global core.editor`) by passing an empty `--comment` (_also works with an empty title_)
+
+-   To disable this functionality of opening your editor add `"use_editor": false` to `~/.gh.json`
 
 ```
 gh is 1 --comment

--- a/default.gh.json
+++ b/default.gh.json
@@ -18,6 +18,8 @@
 
     "github_user": "",
 
+    "use_editor": true,
+
     "hooks": {
         "issue": {
             "close": {

--- a/src/cmds/issue.ts
+++ b/src/cmds/issue.ts
@@ -226,9 +226,11 @@ function browser(user, repo, number) {
 }
 
 function comment(options) {
+    const useEditor = options.config.use_editor !== false
+
     let body = logger.applyReplacements(options.comment, config.replace) + config.signature
 
-    if (userLeftMsgEmpty(options.comment)) {
+    if (useEditor && userLeftMsgEmpty(options.comment)) {
         body = openFileInEditor(
             'temp-gh-issue-comment.md',
             '<!-- Add an issue comment message in markdown format below -->'
@@ -346,6 +348,8 @@ async function listFromAllRepositories(options) {
 
 function newIssue(options) {
     options = produce(options, draft => {
+        const useEditor = draft.config.use_editor !== false
+
         if (draft.labels) {
             draft.labels = draft.labels.split(',')
         } else {
@@ -356,7 +360,7 @@ function newIssue(options) {
             draft.message = logger.applyReplacements(draft.message, config.replace)
         }
 
-        if (userLeftMsgEmpty(draft.title)) {
+        if (useEditor && userLeftMsgEmpty(draft.title)) {
             draft.title = openFileInEditor(
                 'temp-gh-issue-title.txt',
                 '# Add a issue title message on the next line'
@@ -365,7 +369,7 @@ function newIssue(options) {
 
         // If user passes an empty title and message, --message will get merged into options.title
         // Need to reference the original title not the potentially modified one
-        if (userLeftMsgEmpty(options.title) || userLeftMsgEmpty(draft.message)) {
+        if (useEditor && (userLeftMsgEmpty(options.title) || userLeftMsgEmpty(draft.message))) {
             draft.message = openFileInEditor(
                 'temp-gh-issue-body.md',
                 '<!-- Add an issue body message in markdown format below -->'

--- a/src/cmds/pull-request.ts
+++ b/src/cmds/pull-request.ts
@@ -295,10 +295,12 @@ async function close(options) {
 }
 
 async function comment(options) {
+    const useEditor = options.config.use_editor !== false
+
     let body =
         logger.applyReplacements(options.comment, options.config.replace) + options.config.signature
 
-    if (userLeftMsgEmpty(body)) {
+    if (useEditor && userLeftMsgEmpty(body)) {
         body = openFileInEditor(
             'temp-gh-pr-comment.md',
             '<!-- Add an pr comment message in markdown format below -->'
@@ -828,6 +830,7 @@ function sortPullsByComplexity_(pulls, direction) {
 }
 
 async function submit(options, user) {
+    const useEditor = options.config.use_editor !== false
     let description = options.description
     let title = options.title
     let pullBranch = options.pullBranch || options.currentBranch
@@ -837,15 +840,14 @@ async function submit(options, user) {
     }
 
     if (userLeftMsgEmpty(title)) {
-        title = openFileInEditor(
-            'temp-gh-pr-title.txt',
-            `# Add a pr title message on the next line\n${git.getLastCommitMessage(pullBranch)}`
-        )
+        title = useEditor
+            ? openFileInEditor('temp-gh-pr-title.txt', `# Add a pr title message on the next line`)
+            : git.getLastCommitMessage(pullBranch)
     }
 
     // If user passes an empty title and description, --description will get merged into options.title
     // Need to reference the original title not the potentially modified one
-    if (userLeftMsgEmpty(options.title) || userLeftMsgEmpty(description)) {
+    if (useEditor && (userLeftMsgEmpty(options.title) || userLeftMsgEmpty(description))) {
         description = openFileInEditor(
             'temp-gh-pr-body.md',
             '<!-- Add an pr body message in markdown format below -->'


### PR DESCRIPTION
Adding `"use_editor": false` to `~/.gh.json` will now not open editor for messages.

For PRs with this setting off, title will be computed from the last commit msg.