### PR TITLE
fix(json): add default.gh.json to npm published files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "gh",
-    "version": "2.5.1",
+    "version": "2.7.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -212,6 +212,7 @@
         "lib",
         "README.md",
         "LICENSE.txt",
+        "default.gh.json",
         "bin"
     ],
     "keywords": [


### PR DESCRIPTION
Fix `Error: ENOENT: no such file or directory` upon initial install.